### PR TITLE
Improve test helpers

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -13,6 +13,7 @@ read_globals = {
   "string",
   "struct",
   "table",
+  "type",
 }
 
 ignore = {

--- a/modules/colors.lua
+++ b/modules/colors.lua
@@ -1,6 +1,6 @@
 #!lua name=colors
 
--- Make Redis understand colors
+-- Let Redis see colors
 --
 -- RGBA values
 --

--- a/modules/colors.lua
+++ b/modules/colors.lua
@@ -87,9 +87,20 @@ end
 --
 -- Support color manipulation: darken, lighten, adjust opacity, …, shift
 
-local prefix = "c"
+if redis then
+  local prefix = "c"
 
-redis.register_function(prefix .. "setrgba", setrgba)
-redis.register_function(prefix .. "getrgba", getrgba)
-redis.register_function(prefix .. "setrgb", setrgb)
-redis.register_function(prefix .. "getrgb", getrgb)
+  redis.register_function(prefix .. "setrgba", setrgba)
+  redis.register_function(prefix .. "getrgba", getrgba)
+  redis.register_function(prefix .. "setrgb", setrgb)
+  redis.register_function(prefix .. "getrgb", getrgb)
+end
+
+local exports = {
+  n2rgb = n2rgb,
+  rgb2n = rgb2n,
+  n2rgba = n2rgba,
+  rgba2n = rgba2n,
+}
+
+return exports

--- a/modules/colors.test.lua
+++ b/modules/colors.test.lua
@@ -2,7 +2,10 @@ local test = require "test"
 local fcall = test.fcall
 
 describe("colors", function ()
+  local key = "colors-key"
+
   setup(function ()
+    test.invoke("DEL", key)
     test.load("colors.lua")
   end)
 
@@ -10,7 +13,9 @@ describe("colors", function ()
     test.unload("colors")
   end)
 
-  local key = "colors-key"
+  after_each(function ()
+    test.invoke("DEL", key)
+  end)
 
   it("sets/gets rgba colors", function ()
     assert.are.equal("OK", fcall("csetrgba", 1, key, 255, 12, 127, 255))

--- a/modules/test/init.lua
+++ b/modules/test/init.lua
@@ -3,11 +3,11 @@ local json = require "dkjson"
 local test = {}
 
 test.load = function (path)
-  assert(os.execute("cat '" .. path .. "' | redis-cli -x FUNCTION LOAD REPLACE > /dev/null"))
+  assert(os.execute("cat '" .. path .. "' | redis-cli -e -x FUNCTION LOAD REPLACE > /dev/null"))
 end
 
 test.unload = function (name)
-  assert(os.execute("redis-cli FUNCTION DELETE '" .. name .. "' > /dev/null"))
+  assert(os.execute("redis-cli -e FUNCTION DELETE '" .. name .. "' > /dev/null"))
 end
 
 test.invoke = function (...)


### PR DESCRIPTION
- Clean up keys before/after tests
- Make redis-cli exit with non-zero status on error
- Add exports so modules can be used without Redis
