### PR TITLE
Implement ranking with time-based tie-breaking

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,6 +1,7 @@
 return {
   default = {
     ROOT = {"."},
+    lazy = true,
     pattern = "%.test%.lua$",
     verbose = true,
   },

--- a/modules/ranking.lua
+++ b/modules/ranking.lua
@@ -1,0 +1,223 @@
+#!lua name=ranking
+
+-- Ranking with time-based tie-breaking
+--
+-- Members with equal scores are ordered by the time of when the score was last
+-- updated, with members who achieved the score earlier being listed first.
+--
+-- Functions
+--
+--   FCALL rkincrby 1 key increment member
+--   FCALL rkscore  1 key member
+--   FCALL rkrank   1 key member
+--   FCALL rkrange  1 key start stop
+--
+-- Complexity
+--
+--   rkincrby   O(log(N))
+--   rkscore    O(1)
+--   rkrank     O(log(N))
+--   rkrange    O(log(N)+M)
+--
+--   N being the number of elements in the sorted set
+--   M the number of elements returned
+--
+-- Underlying storage
+--
+--   Score and time values are encoded into Redis score values such that the
+--   user score is encoded in the most significant digits while the time is
+--   stored in the least significant digits, serving as a tie-breaker for
+--   entries with equal user scores.
+--
+--   See `encode` and `decode`.
+--
+-- Limits
+--
+--   Time values:
+--
+--   minimum = params.time.min
+--   maximum = minimum + (2^params.time.nbits - 1) / 10^params.time.scale
+--
+--   for the default parameters (with nbits=32, scale=0):
+--
+--   minimum = 1672531200 = 2023-01-01 00:00:00 UTC (as configured)
+--   maximum = 5967498495 = 2159-02-07 06:28:15 UTC
+--
+--   Score values:
+--
+--   Redis stores sorted set scores as "double-precision" 64-bit floating point
+--   values, represented as IEEE 754 floating point numbers on all their
+--   supported architectures.
+--
+--   With this, integer values up to 2^53 (and down to -2^53) can be
+--   represented accurately. Between 2^53 and 2^54, everything is multiplied by
+--   2, so the representable numbers are the even ones.
+--
+--   https://en.wikipedia.org/wiki/Double-precision_floating-point_format
+--
+--   As a consequence, score + time values encoded to numbers less than -2^53
+--   or greater than 2^53 have their time resolution reduced by a factor of 2
+--   first, then 4 for even larger values… i.e. 2^53 == 2^53 + 1.
+--
+--   The limits for score values with full time resolution are:
+--
+--   minimum = params.score.min
+--   maximum = minimum +
+--             math.floor(2^(54 - params.time.nbits) / 10^params.score.scale)
+--
+--   for the default parameters (with scale=0, integer score values):
+--
+--   minimum = 0
+--   maximum = 4194304
+--
+-- Trade-offs
+--
+--   Resolution of the timestamps used for tie-breaking is seconds by default.
+--   You can choose to increase it up to microseconds resolution (see `TIME`),
+--   setting params.time.scale and trading increased timestamp resolution for:
+--
+--   1. a reduced time range (if you keep params.time.nbits the same)
+--   2. a reduced score value range (if you increase params.time.nbits)
+--
+--   Conversely, you can reduce timestamp resolution for:
+--
+--   1. a wider time range (keeping params.time.nbits unchanged)
+--   2. a wider score range (reducing params.time.nbits)
+--
+--   You can shift the range of scores in which tie-breaking works with full
+--   time resolution by adjusting params.score.min. If this range is too narrow
+--   for you, you may choose to increase the minimum value, sacrificing time
+--   resolution for those entries at the bottom of the ranking below the
+--   minimum value, but gaining room at the top end. Or you may set a negative
+--   scale if you know your scores are always mutliples of 10, 100, ….
+--
+
+local errors = {
+  nargs = "ERR wrong number of arguments",
+  nkeys = "ERR wrong number of keys",
+}
+
+local params = {
+  time = {
+    nbits = 32, -- number of bits to use for time information
+    scale = 0, -- decimal digits in the fractional part, 0=1s, 1=0.1s, 2=0.01s…
+    min = 1672531200, -- min. expected unix time: 2023-01-01 00:00:00 UTC
+  },
+  score = {
+    scale = 0, -- decimal digits in the fractional part of score values
+    min = 0, -- min. expected score
+  },
+}
+
+local tbits = params.time.nbits
+local step = 2^tbits
+
+local maxsafe = 2^53
+local anchor = step / 2 - maxsafe
+
+local tinc = 10^(6 - params.time.scale)
+local tmin = params.time.min * 1000000
+local tmax = tmin + (2^tbits - 1) * tinc
+
+local sinc = 10^params.time.scale
+local smin = params.score.min
+local smax = smin + 2^(53 + 1 - tbits) / 10^params.score.scale - 2
+
+local function round (value)
+  return math.floor(value + 0.5)
+end
+
+local function clamp (value, min, max)
+  return math.min(math.max(value, min), max)
+end
+
+local function encode (score, timestamp)
+  local left = round((score - smin) / sinc) * step
+  local time = clamp(round((timestamp - tmin) / tinc), 0, step - 1)
+  local right = step / 2 - 1 - time
+  return anchor + left + right
+end
+
+local function decode (value)
+  -- We never use the stored timestamp, so we don't bother extracting it
+  return (round((value - step / 2) / step) + 2^(53 - tbits)) * sinc + smin
+end
+
+local function incrby (keys, args)
+  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
+  if #args ~= 2 then return redis.error_reply(errors.nargs) end
+
+  local key = keys[1]
+  local increment, member = args[1], args[2]
+
+  local value = redis.call("ZSCORE", key, member)
+  local score
+
+  if value then
+    score = decode(value)
+  else
+    score = 0
+  end
+
+  score = score + increment
+
+  local seconds, microseconds = unpack(redis.call("TIME"))
+  local timestamp = seconds * 1000000 + microseconds
+
+  value = encode(score, timestamp)
+
+  redis.call("ZADD", key, value, member)
+
+  return score
+end
+
+local function score (keys, args)
+  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
+  if #args ~= 1 then return redis.error_reply(errors.nargs) end
+  local value = redis.call("ZSCORE", keys[1], args[1])
+  if value == nil then return nil end
+  return decode(value)
+end
+
+local function rank (keys, args)
+  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
+  if #args ~= 1 then return redis.error_reply(errors.nargs) end
+  return redis.call("ZREVRANK", keys[1], args[1])
+end
+
+local function range (keys, args)
+  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
+  if #args ~= 2 then return redis.error_reply(errors.nargs) end
+
+  local start, stop = args[1], args[2]
+
+  local rng = redis.call("ZRANGE", keys[1], start, stop, "REV", "WITHSCORES")
+  local res = {}
+
+  for i=1,#rng,2 do
+    res[i], res[i + 1] = rng[i], decode(rng[i + 1])
+  end
+
+  return res
+end
+
+if redis then
+  local prefix = "rk"
+
+  redis.register_function(prefix .. "incrby", incrby)
+  redis.register_function(prefix .. "score", score)
+  redis.register_function(prefix .. "rank", rank)
+  redis.register_function(prefix .. "range", range)
+end
+
+local exports = {
+  decode = decode,
+  encode = encode,
+  tmin = tmin,
+  tmax = tmax,
+  tinc = tinc,
+  smin = smin,
+  smax = smax,
+}
+
+return exports

--- a/modules/ranking.test.lua
+++ b/modules/ranking.test.lua
@@ -1,0 +1,129 @@
+local test = require "test"
+local fcall = test.fcall
+
+describe("ranking", function ()
+  local key = "ranking-key"
+
+  setup(function ()
+    test.invoke("DEL", key)
+    test.load("ranking.lua")
+  end)
+
+  teardown(function ()
+    test.unload("ranking")
+  end)
+
+  after_each(function ()
+    test.invoke("DEL", key)
+  end)
+
+  it("sets/gets ranking entries", function ()
+    for i=0,6 do
+      local score, member = 10^i, "m:" .. i
+      assert.are.equal(score, fcall("rkincrby", 1, key, score, member))
+      assert.are.equal(score, fcall("rkscore", 1, key, member))
+    end
+  end)
+
+  it("updates ranking entries", function ()
+    local member = "member-key"
+    assert.are.equal(1000, fcall("rkincrby", 1, key, 1000, member))
+    assert.are.equal(1001, fcall("rkincrby", 1, key, 1, member))
+    assert.are.equal(1001, fcall("rkscore", 1, key, member))
+  end)
+
+  it("ranks members", function ()
+    assert.are.equal(4, fcall("rkincrby", 1, key, 4, "a"))
+    assert.are.equal(3, fcall("rkincrby", 1, key, 3, "b"))
+    assert.are.equal(2, fcall("rkincrby", 1, key, 2, "c"))
+    assert.are.equal(0, fcall("rkrank", 1, key, "a"))
+    assert.are.equal(1, fcall("rkrank", 1, key, "b"))
+    assert.are.equal(2, fcall("rkrank", 1, key, "c"))
+  end)
+
+  it("lists members", function ()
+    assert.are.equal(5, fcall("rkincrby", 1, key, 5, "a"))
+    assert.are.equal(4, fcall("rkincrby", 1, key, 4, "b"))
+    assert.are.equal(3, fcall("rkincrby", 1, key, 3, "c"))
+    assert.are.same({"a", 5, "b", 4, "c", 3}, fcall("rkrange", 1, key, 0, -1))
+  end)
+end)
+
+local mod = require "ranking"
+
+describe("ranking.exports", function ()
+  local decode, encode = mod.decode, mod.encode
+  local smax, smin = mod.smax, mod.smin
+  local tmax, tmin = mod.tmax, mod.tmin
+  local tinc = mod.tinc
+
+  local now = os.time() * 1000000
+
+  it("encodes so higher scores produce higher values", function ()
+    assert.is_true(encode(1, now) > encode(0, now))
+  end)
+
+  it("encodes so higher timestamps produce lower values", function ()
+    assert.are.equal(encode(0, now + tinc), encode(0, now) - 1)
+  end)
+
+  it("encodes and decodes simple values", function ()
+    for _, o in ipairs({0, 1, 17, 91, 131, 2000000}) do
+      local v = smin + o
+      assert.are.equal(v, decode(encode(v, tmin)))
+      assert.are.equal(v, decode(encode(v, now)))
+      assert.are.equal(v, decode(encode(v, tmax)))
+    end
+  end)
+
+  it("encodes and decodes high values", function ()
+    local v = smin + ((smax - smin) / 2) - 1
+
+    assert.are.equal(v, decode(encode(v, tmin)))
+    assert.are.equal(v, decode(encode(v, now)))
+    assert.are.equal(v, decode(encode(v, tmax)))
+
+    -- if assertions above succeed, but those below break,
+    -- we are only getting half the promised score range
+
+    v = v + 1
+
+    assert.are.equal(v, decode(encode(v, tmin)))
+    assert.are.equal(v, decode(encode(v, now)))
+    assert.are.equal(v, decode(encode(v, tmax)))
+  end)
+
+  it("encodes and decodes values near the bottom edge", function ()
+    for _, v in ipairs({smin, smin + 1}) do
+      assert.are.equal(v, decode(encode(v, tmin)))
+      assert.are.equal(v, decode(encode(v, now)))
+      assert.are.equal(v, decode(encode(v, tmax)))
+    end
+  end)
+
+  it("encodes and decodes values near the top edge", function ()
+    for _, v in ipairs({smax - 1, smax}) do
+      assert.are.equal(v, decode(encode(v, tmin)))
+      assert.are.equal(v, decode(encode(v, now)))
+      assert.are.equal(v, decode(encode(v, tmax)))
+    end
+  end)
+
+  it("encodes with full time resolution within the boundaries", function ()
+    for _, v in ipairs({smin, smax}) do
+      assert.are.equal(encode(v, tmin + 2 * tinc), encode(v, tmin + tinc) - 1)
+      assert.are.equal(encode(v, tmax - 2 * tinc), encode(v, tmax - tinc) + 1)
+      assert.are.equal(encode(v, tmin + tinc), encode(v, tmin) - 1)
+      assert.are.equal(encode(v, tmax - tinc), encode(v, tmax) + 1)
+    end
+  end)
+
+  it("prevents out-of-range timestamp values from changing scores", function ()
+    assert.are.equal(smin, decode(encode(smin, tmin - 1)))
+    assert.are.equal(smin, decode(encode(smin, tmax + 1)))
+    assert.are.equal(smin, decode(encode(smin, tmin - tinc)))
+    assert.are.equal(smin, decode(encode(smin, tmax + tinc)))
+    assert.are.equal(smin, decode(encode(smin, tmin - 2 * tinc)))
+    assert.are.equal(smin, decode(encode(smin, tmax + 2 * tinc)))
+  end)
+end)


### PR DESCRIPTION
Redis sorted sets fall back to sorting lexicographically by member key for entries with equal score. For rankings/leaderboards this seems undesirable – why should you end up on a lower rank just because someone uses "aaa…" as a username (silly example, but you get the idea).

This implementation instead uses timestamps to order entries with equal score. Those entries that were created earlier get a better rank.

Example:

| Rank | Score | Time                |
| ---- | ----- | ------------------- |
| 0    | 100   | 2023.01.01 00:00:00 |
| 1    | 99    | 2023.01.01 00:00:00 |
| 2    | 99    | 2023.01.01 00:00:01 |
| 3    | 34    | 2023.01.01 00:00:00 |
