### PR TITLE
Allow ranking module to be used with custom params

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -20,6 +20,7 @@ local lua51 = stds.lua51.read_globals
 
 stds.redis = {
   read_globals = {
+    setmetatable = lua51.setmetatable,
     type = lua51.type,
     unpack = lua51.unpack,
 

--- a/modules/ranking.lua
+++ b/modules/ranking.lua
@@ -5,6 +5,8 @@
 -- Members with equal scores are ordered by the time of when the score was last
 -- updated, with members who achieved the score earlier being listed first.
 --
+-- Scores are assumed to be integer values.
+--
 -- Functions
 --
 --   FCALL rkincrby 1 key increment member
@@ -65,7 +67,7 @@
 --   maximum = minimum +
 --             math.floor(2^(54 - params.time.nbits) / 10^params.score.scale)
 --
---   for the default parameters (with scale=0, integer score values):
+--   for the default parameters (min=0):
 --
 --   minimum = 0
 --   maximum = 4194304
@@ -88,8 +90,11 @@
 --   time resolution by adjusting params.score.min. If this range is too narrow
 --   for you, you may choose to increase the minimum value, sacrificing time
 --   resolution for those entries at the bottom of the ranking below the
---   minimum value, but gaining room at the top end. Or you may set a negative
---   scale if you know your scores are always mutliples of 10, 100, ….
+--   minimum value, but gaining room at the top end.
+--
+--   If you know your scores are always mutliples of 10, 100, … or some other
+--   factor, you can divide them by this factor before passing them in and
+--   multiply any retrieved values to get back your original score.
 --
 
 local errors = {
@@ -97,31 +102,18 @@ local errors = {
   nkeys = "ERR wrong number of keys",
 }
 
-local params = {
+local defaults = {
   time = {
     nbits = 32, -- number of bits to use for time information
     scale = 0, -- decimal digits in the fractional part, 0=1s, 1=0.1s, 2=0.01s…
     min = 1672531200, -- min. expected unix time: 2023-01-01 00:00:00 UTC
   },
   score = {
-    scale = 0, -- decimal digits in the fractional part of score values
     min = 0, -- min. expected score
   },
 }
 
-local tbits = params.time.nbits
-local step = 2^tbits
-
 local maxsafe = 2^53
-local anchor = step / 2 - maxsafe
-
-local tinc = 10^(6 - params.time.scale)
-local tmin = params.time.min * 1000000
-local tmax = tmin + (2^tbits - 1) * tinc
-
-local sinc = 10^params.time.scale
-local smin = params.score.min
-local smax = smin + 2^(53 + 1 - tbits) / 10^params.score.scale - 2
 
 local function round (value)
   return math.floor(value + 0.5)
@@ -131,19 +123,47 @@ local function clamp (value, min, max)
   return math.min(math.max(value, min), max)
 end
 
-local function encode (score, timestamp)
-  local left = round((score - smin) / sinc) * step
-  local time = clamp(round((timestamp - tmin) / tinc), 0, step - 1)
-  local right = step / 2 - 1 - time
-  return anchor + left + right
+local function init (params)
+  local o = {}
+  local tbits = params.time.nbits
+
+  o.tbits = tbits
+  o.step = 2^tbits
+
+  o.anchor = o.step / 2 - maxsafe
+
+  o.tinc = 10^(6 - params.time.scale)
+  o.tmin = params.time.min * 1000000
+  o.tmax = o.tmin + (2^tbits - 1) * o.tinc
+
+  o.smin = params.score.min
+  o.smax = o.smin + 2^(53 + 1 - tbits) - 2
+
+  return o
 end
 
-local function decode (value)
+local Codec = {}
+
+function Codec:new (params)
+  local codec = init(params or defaults)
+  setmetatable(codec, self)
+  self.__index = self
+  return codec
+end
+
+function Codec:encode (score, timestamp)
+  local left = round((score - self.smin)) * self.step
+  local time = clamp(round((timestamp - self.tmin) / self.tinc), 0, self.step - 1)
+  local right = self.step / 2 - 1 - time
+  return self.anchor + left + right
+end
+
+function Codec:decode (value)
   -- We never use the stored timestamp, so we don't bother extracting it
-  return (round((value - step / 2) / step) + 2^(53 - tbits)) * sinc + smin
+  return (round((value - self.step / 2) / self.step) + 2^(53 - self.tbits)) + self.smin
 end
 
-local function incrby (keys, args)
+local function incrby (codec, keys, args)
   if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
   if #args ~= 2 then return redis.error_reply(errors.nargs) end
 
@@ -154,7 +174,7 @@ local function incrby (keys, args)
   local score
 
   if value then
-    score = decode(value)
+    score = codec:decode(value)
   else
     score = 0
   end
@@ -164,28 +184,22 @@ local function incrby (keys, args)
   local seconds, microseconds = unpack(redis.call("TIME"))
   local timestamp = seconds * 1000000 + microseconds
 
-  value = encode(score, timestamp)
+  value = codec:encode(score, timestamp)
 
   redis.call("ZADD", key, value, member)
 
   return score
 end
 
-local function score (keys, args)
+local function score (codec, keys, args)
   if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
   if #args ~= 1 then return redis.error_reply(errors.nargs) end
   local value = redis.call("ZSCORE", keys[1], args[1])
   if value == nil then return nil end
-  return decode(value)
+  return codec:decode(value)
 end
 
-local function rank (keys, args)
-  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
-  if #args ~= 1 then return redis.error_reply(errors.nargs) end
-  return redis.call("ZREVRANK", keys[1], args[1])
-end
-
-local function range (keys, args)
+local function range (codec, keys, args)
   if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
   if #args ~= 2 then return redis.error_reply(errors.nargs) end
 
@@ -195,29 +209,35 @@ local function range (keys, args)
   local res = {}
 
   for i=1,#rng,2 do
-    res[i], res[i + 1] = rng[i], decode(rng[i + 1])
+    res[i], res[i + 1] = rng[i], codec:decode(rng[i + 1])
   end
 
   return res
 end
 
+local function rank (keys, args)
+  if #keys ~= 1 then return redis.error_reply(errors.nkeys) end
+  if #args ~= 1 then return redis.error_reply(errors.nargs) end
+  return redis.call("ZREVRANK", keys[1], args[1])
+end
+
 if redis then
   local prefix = "rk"
 
-  redis.register_function(prefix .. "incrby", incrby)
-  redis.register_function(prefix .. "score", score)
-  redis.register_function(prefix .. "rank", rank)
-  redis.register_function(prefix .. "range", range)
+  local function rkincrby (...) return incrby(Codec:new(defaults), ...) end
+  local function rkscore (...) return score(Codec:new(defaults), ...) end
+  local function rkrange (...) return range(Codec:new(defaults), ...) end
+  local rkrank = rank -- no codec needed
+
+  redis.register_function(prefix .. "incrby", rkincrby)
+  redis.register_function(prefix .. "score", rkscore)
+  redis.register_function(prefix .. "range", rkrange)
+  redis.register_function(prefix .. "rank", rkrank)
 end
 
 local exports = {
-  decode = decode,
-  encode = encode,
-  tmin = tmin,
-  tmax = tmax,
-  tinc = tinc,
-  smin = smin,
-  smax = smax,
+  new = function (...) return Codec:new(...) end,
+  defaults = defaults,
 }
 
 return exports

--- a/modules/ranking.test.lua
+++ b/modules/ranking.test.lua
@@ -51,79 +51,104 @@ end)
 
 local mod = require "ranking"
 
-describe("ranking.exports", function ()
-  local decode, encode = mod.decode, mod.encode
-  local smax, smin = mod.smax, mod.smin
-  local tmax, tmin = mod.tmax, mod.tmin
-  local tinc = mod.tinc
+describe("ranking codec", function ()
+  local defaults = mod.defaults
 
   local now = os.time() * 1000000
 
-  it("encodes so higher scores produce higher values", function ()
-    assert.is_true(encode(1, now) > encode(0, now))
-  end)
+  for _, tscale in ipairs({0, 3, 6}) do -- s, ms, μs
+    for _, min in ipairs({0, 2^53, -2^53 + 2}) do
+      local t = it
 
-  it("encodes so higher timestamps produce lower values", function ()
-    assert.are.equal(encode(0, now + tinc), encode(0, now) - 1)
-  end)
+      local function it (description, ...)
+        return t(string.format("%s {time.scale = %g, score.min = %g}", description, tscale, min), ...)
+      end
 
-  it("encodes and decodes simple values", function ()
-    for _, o in ipairs({0, 1, 17, 91, 131, 2000000}) do
-      local v = smin + o
-      assert.are.equal(v, decode(encode(v, tmin)))
-      assert.are.equal(v, decode(encode(v, now)))
-      assert.are.equal(v, decode(encode(v, tmax)))
+      local params = {
+        score = { min = min },
+        time = {
+          nbits = defaults.time.nbits,
+          min = defaults.time.min,
+          scale = tscale,
+        },
+      }
+
+      local c = mod.new(params)
+
+      local decode = function (...) return c:decode(...) end
+      local encode = function (...) return c:encode(...) end
+
+      local smax, smin = c.smax, c.smin
+      local tmax, tmin = c.tmax, c.tmin
+      local tinc = c.tinc
+
+      it("encodes so higher scores produce higher values", function ()
+        assert.is_true(encode(1, now) > encode(0, now))
+      end)
+
+      it("encodes so higher timestamps produce lower values", function ()
+        assert.are.equal(encode(0, now + tinc), encode(0, now) - 1)
+      end)
+
+      it("encodes and decodes simple values", function ()
+        for _, o in ipairs({0, 1, 17, 91, 131, 2000000}) do
+          local v = smin + o
+          assert.are.equal(v, decode(encode(v, tmin)))
+          assert.are.equal(v, decode(encode(v, now)))
+          assert.are.equal(v, decode(encode(v, tmax)))
+        end
+      end)
+
+      it("encodes and decodes high values", function ()
+        local v = smin + ((smax - smin) / 2) - 1
+
+        assert.are.equal(v, decode(encode(v, tmin)))
+        assert.are.equal(v, decode(encode(v, now)))
+        assert.are.equal(v, decode(encode(v, tmax)))
+
+        -- if assertions above succeed, but those below break,
+        -- we are only getting half the promised score range
+
+        v = v + 1
+
+        assert.are.equal(v, decode(encode(v, tmin)))
+        assert.are.equal(v, decode(encode(v, now)))
+        assert.are.equal(v, decode(encode(v, tmax)))
+      end)
+
+      it("encodes and decodes values near the bottom edge", function ()
+        for _, v in ipairs({smin, smin + 1}) do
+          assert.are.equal(v, decode(encode(v, tmin)))
+          assert.are.equal(v, decode(encode(v, now)))
+          assert.are.equal(v, decode(encode(v, tmax)))
+        end
+      end)
+
+      it("encodes and decodes values near the top edge", function ()
+        for _, v in ipairs({smax - 1, smax}) do
+          assert.are.equal(v, decode(encode(v, tmin)))
+          assert.are.equal(v, decode(encode(v, now)))
+          assert.are.equal(v, decode(encode(v, tmax)))
+        end
+      end)
+
+      it("encodes with full time resolution within the boundaries", function ()
+        for _, v in ipairs({smin, smax}) do
+          assert.are.equal(encode(v, tmin + 2 * tinc), encode(v, tmin + tinc) - 1)
+          assert.are.equal(encode(v, tmax - 2 * tinc), encode(v, tmax - tinc) + 1)
+          assert.are.equal(encode(v, tmin + tinc), encode(v, tmin) - 1)
+          assert.are.equal(encode(v, tmax - tinc), encode(v, tmax) + 1)
+        end
+      end)
+
+      it("prevents out-of-range timestamp values from changing scores", function ()
+        assert.are.equal(smin, decode(encode(smin, tmin - 1)))
+        assert.are.equal(smin, decode(encode(smin, tmax + 1)))
+        assert.are.equal(smin, decode(encode(smin, tmin - tinc)))
+        assert.are.equal(smin, decode(encode(smin, tmax + tinc)))
+        assert.are.equal(smin, decode(encode(smin, tmin - 2 * tinc)))
+        assert.are.equal(smin, decode(encode(smin, tmax + 2 * tinc)))
+      end)
     end
-  end)
-
-  it("encodes and decodes high values", function ()
-    local v = smin + ((smax - smin) / 2) - 1
-
-    assert.are.equal(v, decode(encode(v, tmin)))
-    assert.are.equal(v, decode(encode(v, now)))
-    assert.are.equal(v, decode(encode(v, tmax)))
-
-    -- if assertions above succeed, but those below break,
-    -- we are only getting half the promised score range
-
-    v = v + 1
-
-    assert.are.equal(v, decode(encode(v, tmin)))
-    assert.are.equal(v, decode(encode(v, now)))
-    assert.are.equal(v, decode(encode(v, tmax)))
-  end)
-
-  it("encodes and decodes values near the bottom edge", function ()
-    for _, v in ipairs({smin, smin + 1}) do
-      assert.are.equal(v, decode(encode(v, tmin)))
-      assert.are.equal(v, decode(encode(v, now)))
-      assert.are.equal(v, decode(encode(v, tmax)))
-    end
-  end)
-
-  it("encodes and decodes values near the top edge", function ()
-    for _, v in ipairs({smax - 1, smax}) do
-      assert.are.equal(v, decode(encode(v, tmin)))
-      assert.are.equal(v, decode(encode(v, now)))
-      assert.are.equal(v, decode(encode(v, tmax)))
-    end
-  end)
-
-  it("encodes with full time resolution within the boundaries", function ()
-    for _, v in ipairs({smin, smax}) do
-      assert.are.equal(encode(v, tmin + 2 * tinc), encode(v, tmin + tinc) - 1)
-      assert.are.equal(encode(v, tmax - 2 * tinc), encode(v, tmax - tinc) + 1)
-      assert.are.equal(encode(v, tmin + tinc), encode(v, tmin) - 1)
-      assert.are.equal(encode(v, tmax - tinc), encode(v, tmax) + 1)
-    end
-  end)
-
-  it("prevents out-of-range timestamp values from changing scores", function ()
-    assert.are.equal(smin, decode(encode(smin, tmin - 1)))
-    assert.are.equal(smin, decode(encode(smin, tmax + 1)))
-    assert.are.equal(smin, decode(encode(smin, tmin - tinc)))
-    assert.are.equal(smin, decode(encode(smin, tmax + tinc)))
-    assert.are.equal(smin, decode(encode(smin, tmin - 2 * tinc)))
-    assert.are.equal(smin, decode(encode(smin, tmax + 2 * tinc)))
-  end)
+  end
 end)


### PR DESCRIPTION
While we have to hard-code parameters for using the module via Redis functions, we can now use its value encoding functionality with custom parameters from other Lua code. This enables, for instance, testing of the code with different configurations.

This gives me some more confidence about the implementation and its limits.

In the process, I removed the scale for the score values. We now always expect integer values, simplifying the code. Any mapping of non-integer scores or spaced-out scores (multiples of a common factor) can be done by the application.
